### PR TITLE
Replace `iocage reboot` with `iocage restart -H`

### DIFF
--- a/iocage.8
+++ b/iocage.8
@@ -16,8 +16,7 @@
 \fBiocage\fP \fIlist\fP [\fB-t\fP|\fB-r\fP]
 \fBiocage\fP \fIstart\fP UUID|TAG
 \fBiocage\fP \fIstop\fP UUID|TAG
-\fBiocage\fP \fIrestart\fP UUID|TAG
-\fBiocage\fP \fIreboot\fP UUID|TAG
+\fBiocage\fP \fIrestart\fP [\fB-H\fP] UUID|TAG
 \fBiocage\fP \fIrcboot\fP
 \fBiocage\fP \fIrcshutdown\fP
 \fBiocage\fP \fIconsole\fP UUID|TAG
@@ -263,24 +262,19 @@ latest updates applied.
 
 .fam T
 .fi
-\fIrestart\fP \fIUUID\fP|TAG
+\fIrestart\fP [\fB-H\fP] \fIUUID\fP|TAG
 .PP
 .nf
 .fam C
-    Soft restart jail. Soft method will restart the jail without destroying
-    the jail's networking and the jail process itself. All processes are
-    gracefully restarted inside the jail. Useful for quick and graceful
-    restarts.
+    Restart the jail identified by uuid or tag.
 
-.fam T
-.fi
-\fIrestart\fP \fIUUID\fP|TAG
-.PP
-.nf
-.fam C
-    Fully stop and restart the jail, the same as if `iocage stop` and `iocage
-    start` were executed separately.
+    This method will by default restart the jail without destroying the jail's
+    networking and the jail process itself.  All processes are gracefully
+    restarted inside the jail.  Soft restarting is quicker and more graceful
+    than a full stop and start.
 
+    -H    Hard restart.  Overrides the default behavior and instead fully stops
+          and, upon success, starts the jail.
 .fam T
 .fi
 \fIrcboot\fP

--- a/iocage.8
+++ b/iocage.8
@@ -274,7 +274,7 @@ latest updates applied.
     than a full stop and start.
 
     -H    Hard restart.  Overrides the default behavior and instead fully stops
-          and, upon success, starts the jail.
+          and starts the jail.
 .fam T
 .fi
 \fIrcboot\fP

--- a/iocage.8.txt
+++ b/iocage.8.txt
@@ -12,8 +12,7 @@ SYNOPSIS
   iocage list [-t|-r]
   iocage start UUID|TAG
   iocage stop UUID|TAG
-  iocage restart UUID|TAG
-  iocage reboot UUID|TAG
+  iocage restart [-H] UUID|TAG
   iocage rcboot
   iocage rcshutdown
   iocage console UUID|TAG
@@ -191,17 +190,17 @@ SUBCOMMANDS
 
     Stop jail identified by UUID or TAG.
 
-  restart UUID|TAG
+  restart [-H] UUID|TAG
 
-    Soft restart jail. Soft method will restart the jail without destroying
-    the jail's networking and the jail process itself. All processes are
-    gracefully restarted inside the jail. Useful for quick and graceful
-    restarts.
+     Restart the jail identified by uuid or tag.
 
-  reboot UUID|TAG
+     This method will by default restart the jail without destroying the jail's
+     networking and the jail process itself.  All processes are gracefully
+     restarted inside the jail.  Soft restarting is quicker and more graceful
+     than a full stop and start.
 
-    Fully stop and restart the jail, the same as if `iocage stop` and `iocage
-    start` were executed separately.
+     -H      Hard restart.  Overrides the default behavior and instead fully
+             stops and, upon success, starts the jail.
 
   rcboot
 

--- a/iocage.8.txt
+++ b/iocage.8.txt
@@ -200,7 +200,7 @@ SUBCOMMANDS
      than a full stop and start.
 
      -H      Hard restart.  Overrides the default behavior and instead fully
-             stops and, upon success, starts the jail.
+             stops and starts the jail.
 
   rcboot
 

--- a/lib/ioc-cmd
+++ b/lib/ioc-cmd
@@ -730,9 +730,9 @@ __cmd_restart () {
     __check_dataset "${_dataset}" ${_name}
 
     if [ "${_hard}" -eq 0 ] ; then
-        __restart_jail ${_dataset}
+        __soft_restart_jail ${_dataset}
     else
-        __restart_hard_jail ${_dataset}
+        __hard_restart_jail ${_dataset}
     fi
 }
 

--- a/lib/ioc-cmd
+++ b/lib/ioc-cmd
@@ -128,11 +128,6 @@ __parse_cmd () {
                 __cmd_rcshutdown
                 exit
                 ;;
-            reboot)
-                __require_root
-                __cmd_reboot "${@}"
-                exit
-                ;;
             record)
                 __require_root
                 __cmd_record "${@}"
@@ -660,18 +655,6 @@ __cmd_rcshutdown () {
     __rc_jails shutdown
 }
 
-__cmd_reboot () {
-    local _name _dataset
-
-    _name=${1}
-    __check_name "${_name}"
-
-    _dataset=$(__find_jail ${_name})
-    __check_dataset "${_dataset}"
-
-    __reboot_jail ${_dataset}
-}
-
 __cmd_record () {
     local _action _name _dataset
 
@@ -728,7 +711,15 @@ __cmd_reset () {
 }
 
 __cmd_restart () {
-    local _name _dataset
+    local _name _dataset _hard _opt
+
+    while getopts :H _opt; do
+        case $_opt in
+            "H") _hard=1 ;;
+            "?") __fatal_error "Invalid command syntax." ;;
+        esac
+    done
+    shift $((OPTIND - 1))
 
     _name=${1}
     __check_name "${_name}"
@@ -736,7 +727,11 @@ __cmd_restart () {
     _dataset=$(__find_jail ${_name})
     __check_dataset "${_dataset}" ${_name}
 
-    __restart_jail ${_dataset}
+    if [ -z "$_hard" ]; then
+        __restart_jail ${_dataset}
+    else
+        __restart_hard_jail ${_dataset}
+    fi
 }
 
 __cmd_rollback () {

--- a/lib/ioc-cmd
+++ b/lib/ioc-cmd
@@ -711,10 +711,12 @@ __cmd_reset () {
 }
 
 __cmd_restart () {
-    local _name _dataset _hard _opt
+    local _hard _opt _name _dataset
 
-    while getopts :H _opt; do
-        case $_opt in
+    _hard=0
+
+    while getopts ":H" _opt ; do
+        case ${_opt} in
             "H") _hard=1 ;;
             "?") __fatal_error "Invalid command syntax." ;;
         esac
@@ -727,7 +729,7 @@ __cmd_restart () {
     _dataset=$(__find_jail ${_name})
     __check_dataset "${_dataset}" ${_name}
 
-    if [ -z "$_hard" ]; then
+    if [ "${_hard}" -eq 0 ] ; then
         __restart_jail ${_dataset}
     else
         __restart_hard_jail ${_dataset}

--- a/lib/ioc-help
+++ b/lib/ioc-help
@@ -17,8 +17,7 @@ SYNOPSIS
      iocage list [-H] -r|[-btnl]
      iocage start uuid|tag
      iocage stop uuid|tag
-     iocage restart uuid|tag
-     iocage reboot uuid|tag
+     iocage restart [-H] uuid|tag
      iocage rcboot
      iocage rcshutdown
      iocage console uuid|tag
@@ -259,13 +258,17 @@ DESCRIPTION
 
          Stop the jail identified by uuid or tag.
 
-     restart uuid|tag
+     restart [-H] uuid|tag
 
-         Soft restart the jail identified by uuid or tag.  This method will
-         restart the jail without destroying the jail's networking and the jail
-         process itself.  All processes are gracefully restarted inside the
-         jail.  Soft restarting is quicker and more graceful than a full stop
-         and start.
+         Restart the jail identified by uuid or tag.
+
+         This method will by default restart the jail without destroying the
+         jail's networking and the jail process itself.  All processes are
+         gracefully restarted inside the jail.  Soft restarting is quicker and
+         more graceful than a full stop and start.
+
+         -H      Hard restart.  Overrides the default behavior and instead
+                 fully stops and, upon success, starts the jail.
 
      rcboot
 

--- a/lib/ioc-help
+++ b/lib/ioc-help
@@ -268,7 +268,7 @@ DESCRIPTION
          more graceful than a full stop and start.
 
          -H      Hard restart.  Overrides the default behavior and instead
-                 fully stops and, upon success, starts the jail.
+                 fully stops and starts the jail.
 
      rcboot
 

--- a/lib/ioc-rc
+++ b/lib/ioc-rc
@@ -446,8 +446,8 @@ __restart_jail () {
     __set_dataset_ioc_prop last_started=${_date} ${_dataset}
 }
 
-# Hard reboot
-__reboot_jail () {
+# Hard restart
+__restart_hard_jail () {
     local _dataset
 
     _dataset=${1}

--- a/lib/ioc-rc
+++ b/lib/ioc-rc
@@ -420,7 +420,7 @@ __stop_jail () {
 }
 
 # Soft restart
-__restart_jail () {
+__soft_restart_jail () {
     local _dataset _fulluuid _exec_stop _exec_start _jid _tag _date
 
     _dataset=${1}
@@ -447,7 +447,7 @@ __restart_jail () {
 }
 
 # Hard restart
-__restart_hard_jail () {
+__hard_restart_jail () {
     local _dataset
 
     _dataset=${1}


### PR DESCRIPTION
Rationale: avoid cluttering the commands available in iocage

Updated documentation accordingly