### PR TITLE
lib/ioc-cmd: giving an unrecognized command returns the usage text to…

### DIFF
--- a/lib/ioc-cmd
+++ b/lib/ioc-cmd
@@ -181,8 +181,8 @@ __parse_cmd () {
                 exit
                 ;;
             *)
-                __usage
-                exit
+                __usage >&2
+                exit 1
                 ;;
         esac
         shift


### PR DESCRIPTION
… stderr and returns an error